### PR TITLE
Add method to launch job with checkpoint argument

### DIFF
--- a/src/main/java/org/netarchivesuite/heritrix3wrapper/Heritrix3Wrapper.java
+++ b/src/main/java/org/netarchivesuite/heritrix3wrapper/Heritrix3Wrapper.java
@@ -577,6 +577,29 @@ public class Heritrix3Wrapper {
     }
 
     /**
+     * Launch a built job in pause state, resuming the crawl from the supplied checkpoint.
+     * @param jobname job name
+     * @param checkpoint checkpoint name
+     * @return job state
+     */
+    public JobResult launchJob(String jobname, String checkpoint) {
+        HttpPost postRequest = new HttpPost(baseUrl + "job/" + jobname);
+        List<NameValuePair> nvp = new LinkedList<NameValuePair>();
+        nvp.add(new BasicNameValuePair("action", "launch"));
+        nvp.add(new BasicNameValuePair("checkpoint", checkpoint));
+        StringEntity postEntity = null;
+        try {
+            postEntity = new UrlEncodedFormEntity(nvp);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        postEntity.setContentType("application/x-www-form-urlencoded");
+        postRequest.addHeader("Accept", "application/xml");
+        postRequest.setEntity(postEntity);
+        return jobResult(postRequest);
+    }
+
+    /**
      * Pause running job.
      * @param jobname job name
      * @return job state


### PR DESCRIPTION
At some point the Heritrix ReST API was updated to include the option to launch a job from a checkpoint (https://heritrix.readthedocs.io/en/latest/api.html#launch-job), but I noticed this option was missing in heritrix3-wrapper. This PR adds the missing method.